### PR TITLE
Move initialization to the Options menu

### DIFF
--- a/CertificateShortcutProvider/CertificateShortcutProvider.cs
+++ b/CertificateShortcutProvider/CertificateShortcutProvider.cs
@@ -45,14 +45,9 @@ namespace CertificateShortcutProvider
 
             if (ctx.CreatingNewKey)
             {
-                // Show the key file creation form and always return null,
-                // so that it's not possible to accidentally create a composite key with this provider.
-
-                using (var form = new KeyCreationForm(keyFilePath))
-                {
-                    form.ShowDialog();
-                    return null;
-                }
+                // Always return null, so that it's not possible to accidentally create a composite key with this provider.
+                MessageBox.Show("Certificate Shortcut Provider uses the encrypted master key to access the database. There is no initialization needed other than the master key.\n\nUse 'Options > Initialize Certificate Shortcut Provider...' from the menu to create the encrypted master key.", Name, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return null;
             }
             else
             {

--- a/CertificateShortcutProvider/CertificateShortcutProvider.cs
+++ b/CertificateShortcutProvider/CertificateShortcutProvider.cs
@@ -28,6 +28,14 @@ namespace CertificateShortcutProvider
             }
         }
 
+        public override bool GetKeyMightShowGui
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         public override byte[] GetKey(KeyProviderQueryContext ctx)
         {
             // The key file is expected to be next to the database by default:

--- a/CertificateShortcutProvider/CertificateShortcutProvider.cs
+++ b/CertificateShortcutProvider/CertificateShortcutProvider.cs
@@ -20,6 +20,14 @@ namespace CertificateShortcutProvider
             get { return "Certificate Shortcut Provider"; }
         }
 
+        public override bool SecureDesktopCompatible
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         public override byte[] GetKey(KeyProviderQueryContext ctx)
         {
             // The key file is expected to be next to the database by default:

--- a/CertificateShortcutProvider/CertificateShortcutProviderExt.cs
+++ b/CertificateShortcutProvider/CertificateShortcutProviderExt.cs
@@ -1,9 +1,11 @@
 ﻿using KeePass.Plugins;
+using KeePassLib.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace CertificateShortcutProvider
 {
@@ -23,6 +25,28 @@ namespace CertificateShortcutProvider
         public override void Terminate()
         {
             _host.KeyProviderPool.Remove(_provider);
+        }
+
+        public override ToolStripMenuItem GetMenuItem(PluginMenuType t)
+        {
+            if (t == PluginMenuType.Main)
+            {
+                ToolStripMenuItem tsmi = new ToolStripMenuItem();
+                tsmi.Text = "Initialize Certificate Shortcut Provider...";
+                tsmi.Click += this.onOptionsClicked;
+                return tsmi;
+            }
+            return null;
+        }
+
+        private void onOptionsClicked(object sender, EventArgs e)
+        {
+            var keyFilePath = UrlUtil.StripExtension(_host.Database.IOConnectionInfo.Path) + CertificateShortcutProvider.DefaultKeyExtension;
+
+            using (var form = new KeyCreationForm(keyFilePath))
+            {
+                form.ShowDialog();
+            }
         }
     }
 }

--- a/CertificateShortcutProvider/CryptoHelpers.cs
+++ b/CertificateShortcutProvider/CryptoHelpers.cs
@@ -23,9 +23,10 @@ namespace CertificateShortcutProvider
             // (asymmetric encryption is not suited to encrypt a lot of data)
 
             // symmetric encryption:
+            byte[] iv = { };
             var randomKey = new ProtectedBinary(true, CryptoRandom.Instance.GetRandomBytes(32));
             var passphraseBinary = new ProtectedBinary(true, passphrase.ReadUtf8());
-            var encryptedPassphrase = EncryptSecret(passphraseBinary, randomKey, out var iv);
+            var encryptedPassphrase = EncryptSecret(passphraseBinary, randomKey, out iv);
 
             // now we asymmetrically encrypt the random key.
             byte[] encryptedRandomKey;

--- a/CertificateShortcutProvider/KeyCreationForm.resx
+++ b/CertificateShortcutProvider/KeyCreationForm.resx
@@ -118,10 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve">
-    <value>Please create your Certificate Shortcut Provider Key file.
-
-Once you have saved your key file, uncheck this provider
-from the list of providers in the composite key creation window.
+    <value>Certificate Shortcut Provider uses the encrypted master key to access the database.
+Use this dialog to create the encrypted master password.
 
 If you create a composite key with only a master password,
 you will be able to open your KeePass database by either:


### PR DESCRIPTION
Creating the key file should not be done during the composite key creation, this is rather confusing to the user. I've added a menu entry to create the keyfile instead.

As a sidenote: I still find the process of switching between password and smartcard rather cumbersome: The user needs to check *password* and uncheck *key provider* to use only the master password or he needs to check *key provider* and uncheck the *password*. This *should* work automatically without any clicks. Think of the Windows login process: If a smart card is phyisically detected, then the Smart card PIN is prompted, if no card is detected then the user password is prompted. This doesn't need any other user interaction. Would that be possible within KeePass2?